### PR TITLE
Add whitespace character in regexp.

### DIFF
--- a/x86-lookup.el
+++ b/x86-lookup.el
@@ -137,7 +137,7 @@ This function accepts two arguments: filename and page number."
   "Create an index alist from PDF mapping mnemonics to page numbers.
 This function requires the pdftotext command line program."
   (let ((mnemonic (concat "INSTRUCTION SET REFERENCE, [A-Z]-[A-Z]\n\n"
-                          "\\([[:alnum:]/]+\\) ?—"))
+                          "\\([[:alnum:]/\s]+\\) ?—"))
         (case-fold-search nil))
     (with-temp-buffer
       (call-process x86-lookup-pdftotext-program nil t nil


### PR DESCRIPTION
Headings for some mnemonics contain spaces(eg. INT).

These are the mnemonics that get added with this change:

```
(("int 3" . 944)
 ("into" . 944)
 ("int n" . 944)
 ("fucomip" . 815)
 (" fucomi" . 815)
 ("fcomip" . 815)
 ("fcomi" . 815))
```

(I am using the April 2016 version of the manual.)
