### PR TITLE
Make `x86-lookup-create-index' coding-system robust.

### DIFF
--- a/x86-lookup.el
+++ b/x86-lookup.el
@@ -140,6 +140,8 @@ This function accepts two arguments: filename and page number."
 This function requires the pdftotext command line program."
   (let ((mnemonic (concat "INSTRUCTION SET REFERENCE, [A-Z]-[A-Z]\n\n"
                           "\\([[:alnum:]/ ]+\\)[- ]?—"))
+		(coding-system-for-read 'utf-8)
+		(coding-system-for-write 'utf-8)
         (case-fold-search nil))
     (with-temp-buffer
       (call-process x86-lookup-pdftotext-program nil t nil


### PR DESCRIPTION
The mnemonic regexp in `x86-lookup-create-index' does not work if, for
example, the coding system is `latin-0'; this is because the temporary
buffer filled by `(call-process x86-lookup-pdftotext-program ...)' may
be not encodable in non-UTF-8 coding system, and hence will generate
spurious characters that disrupt the regexp matching.

This patch binds the `coding-system-for-read' and
`coding-system-for-write' to `utf-8' prior to `call-process' in
`x86-lookup-create-index' to make the index creation coding-system robust.