### PR TITLE
Improve opcode reference detection robustness.

### DIFF
--- a/x86-lookup.el
+++ b/x86-lookup.el
@@ -139,12 +139,11 @@ This function accepts two arguments: filename and page number."
   "Create an index alist from PDF mapping mnemonics to page numbers.
 This function requires the pdftotext command line program."
   (let ((mnemonic (concat "\\(?:.*\n\n?\\)?"
-                          "\\([[:alnum:]/[:blank:]]+\\)[[:blank:]]*\\(?:--\\|—\\).*\n\n?"
-                          "Opcode"
-                          ))
+                          "\\([[:alnum:]/[:blank:]]+\\)[[:blank:]]*\\(?:--\\|—\\)\\(?:.*\n\n?\\)\\{1,3\\}"
+                          "[[:blank:]]*Opcode"))
         (coding-system-for-read 'utf-8)
         (coding-system-for-write 'utf-8)
-        (case-fold-search nil))
+        (case-fold-search t))
     (with-temp-buffer
       (call-process x86-lookup-pdftotext-program nil t nil
                     (file-truename pdf) "-")

--- a/x86-lookup.el
+++ b/x86-lookup.el
@@ -138,8 +138,10 @@ This function accepts two arguments: filename and page number."
 (cl-defun x86-lookup-create-index (&optional (pdf x86-lookup-pdf))
   "Create an index alist from PDF mapping mnemonics to page numbers.
 This function requires the pdftotext command line program."
-  (let ((mnemonic (concat "INSTRUCTION SET REFERENCE, [A-Z]-[A-Z]\n\n"
-                          "\\([[:alnum:]/ ]+\\)[- ]?—"))
+  (let ((mnemonic (concat "\\(?:.*\n\n?\\)?"
+                          "\\([[:alnum:]/[:blank:]]+\\)[[:blank:]]*\\(?:--\\|—\\).*\n\n?"
+                          "Opcode"
+                          ))
         (coding-system-for-read 'utf-8)
         (coding-system-for-write 'utf-8)
         (case-fold-search nil))


### PR DESCRIPTION
The current opcode regexp fails to detect opcode reference in
the following cases.
* Texts extracted using non-Poppler (Glyph & Cog) `pdftotext` in
  Windows, which sometimes omit the headnote and begin directly with
  the opcode itself.
* Instructions that have a different headnote pattern, e.g., VMX
  instructions.

This changeset updates the opcode regexp to address the
above issues.