### PR TITLE
Add Sumatra PDF as a PDF browser and adjust the default PDF browser ranking.

### DIFF
--- a/x86-lookup.el
+++ b/x86-lookup.el
@@ -255,6 +255,10 @@ Defaults to the mnemonic under point."
   "View PDF at PAGE using zathura."
   (start-process "zathura" nil "zathura" "-P" (format "%d" page) "--" pdf))
 
+(defun x86-lookup-browse-pdf-sumatrapdf (pdf page)
+  "View PDF at PAGE using Sumatra PDF."
+  (start-process "sumatrapdf" nil "sumatrapdf" "-page" (format "%d" page) pdf))
+
 (defun x86-lookup-browse-pdf-mupdf (pdf page)
   "View PDF at PAGE using MuPDF."
   ;; MuPDF doesn't have a consistent name across platforms.
@@ -270,15 +274,16 @@ Defaults to the mnemonic under point."
 
 (defun x86-lookup-browse-pdf-any (pdf page)
   "Try visiting PDF using the first viewer found."
-  (or (ignore-errors (x86-lookup-browse-pdf-pdf-tools pdf page))
-      (ignore-errors (x86-lookup-browse-pdf-doc-view pdf page))
-      (ignore-errors (x86-lookup-browse-pdf-evince pdf page))
+  (or (ignore-errors (x86-lookup-browse-pdf-evince pdf page))
+      (ignore-errors (x86-lookup-browse-pdf-sumatrapdf pdf page))
       (ignore-errors (x86-lookup-browse-pdf-xpdf pdf page))
       (ignore-errors (x86-lookup-browse-pdf-okular pdf page))
       (ignore-errors (x86-lookup-browse-pdf-gv pdf page))
       (ignore-errors (x86-lookup-browse-pdf-zathura pdf page))
       (ignore-errors (x86-lookup-browse-pdf-mupdf pdf page))
       (ignore-errors (x86-lookup-browse-pdf-browser pdf page))
+      (ignore-errors (x86-lookup-browse-pdf-pdf-tools pdf page))
+      (ignore-errors (x86-lookup-browse-pdf-doc-view pdf page))
       (error "Could not find a PDF viewer.")))
 
 (provide 'x86-lookup)

--- a/x86-lookup.el
+++ b/x86-lookup.el
@@ -77,6 +77,8 @@ This function accepts two arguments: filename and page number."
                                 x86-lookup-browse-pdf-zathura)
                  (function-item :tag "MuPDF" :value
                                 x86-lookup-browse-pdf-mupdf)
+                 (function-item :tag "Sumatra PDF" :value
+                                x86-lookup-browse-pdf-sumatrapdf)
                  (function-item :tag "browse-url"
                                 :value x86-lookup-browse-pdf-browser)
                  (function :tag "Your own function")))
@@ -274,16 +276,16 @@ Defaults to the mnemonic under point."
 
 (defun x86-lookup-browse-pdf-any (pdf page)
   "Try visiting PDF using the first viewer found."
-  (or (ignore-errors (x86-lookup-browse-pdf-evince pdf page))
-      (ignore-errors (x86-lookup-browse-pdf-sumatrapdf pdf page))
+  (or (ignore-errors (x86-lookup-browse-pdf-pdf-tools pdf page))
+      (ignore-errors (x86-lookup-browse-pdf-doc-view pdf page))
+      (ignore-errors (x86-lookup-browse-pdf-evince pdf page))
       (ignore-errors (x86-lookup-browse-pdf-xpdf pdf page))
       (ignore-errors (x86-lookup-browse-pdf-okular pdf page))
       (ignore-errors (x86-lookup-browse-pdf-gv pdf page))
       (ignore-errors (x86-lookup-browse-pdf-zathura pdf page))
       (ignore-errors (x86-lookup-browse-pdf-mupdf pdf page))
+      (ignore-errors (x86-lookup-browse-pdf-sumatrapdf pdf page))
       (ignore-errors (x86-lookup-browse-pdf-browser pdf page))
-      (ignore-errors (x86-lookup-browse-pdf-pdf-tools pdf page))
-      (ignore-errors (x86-lookup-browse-pdf-doc-view pdf page))
       (error "Could not find a PDF viewer.")))
 
 (provide 'x86-lookup)


### PR DESCRIPTION
Most of the current PDF browsers are *nix based, with Evince being an
exception. However, the Windows port of Evince is currently offline.
This leaves the need for a substitute PDF browser on Windows.

Sumatra PDF (https://www.sumatrapdfreader.org/free-pdf-reader.html) fits
the bill.

Also, the Emacs built-in `doc-view' browser ranks higher than most
external PDF browsers (such as Evince) in the current default PDF browser
ranking. This is perhaps motivated by the doc-view's
immediate availability in Emacs without external dependencies.

However, field test indicates that opening the currently 20+MB combined
Intel Architecture Software Developer's Manual (Intel SDM) would hang
`doc-view' along with the Emacs session in which it embeds. Fortunately,
external PDF browsers such as Evince and Sumatra PDF do not suffer from
this issue: They can usually open the combined Intel SDM in a few
seconds.

Hence, in addition to adding Sumatra PDF as a PDF browser, this changeset
de-prioritizes `doc-view' as a last resort.