### PR TITLE
Add an interactive function to forcibly sync index.

### DIFF
--- a/x86-lookup.el
+++ b/x86-lookup.el
@@ -197,6 +197,22 @@ This function requires the pdftotext command line program."
         (x86-lookup--save-index x86-lookup-pdf x86-lookup-index)))))
   x86-lookup-index)
 
+(defun x86-lookup-ensure-and-update-index ()
+  "Ensure the PDF index has been created and (unconditionally) updated.
+Useful for forcibly syncing the index with the current PDF without resorting 
+to manual deletion of index file on filesystem."
+  (interactive)
+  (cond
+   ((null x86-lookup-pdf)
+    (error "No PDF available. Set `x86-lookup-pdf'."))
+   ((not (file-exists-p x86-lookup-pdf))
+    (error "PDF not found. Check `x86-lookup-pdf'."))
+   ((progn
+      (message "Generating mnemonic index ...")
+      (setf x86-lookup-index (x86-lookup-create-index))
+      (x86-lookup--save-index x86-lookup-pdf x86-lookup-index)
+      (message "Finish generating mnemonic index.")))))
+
 (defun x86-lookup-browse-pdf (pdf page)
   "Launch a PDF viewer using `x86-lookup-browse-pdf-function'."
   (funcall x86-lookup-browse-pdf-function pdf page))


### PR DESCRIPTION
Add `x86-lookup-ensure-and-update-index` to ensure the PDF index has
been created and (unconditionally) updated. Useful for forcibly syncing
the index with the current PDF without resorting to manual deletion of
index on filesystem.