### PR TITLE
Fix typo in package description

### DIFF
--- a/x86-lookup.el
+++ b/x86-lookup.el
@@ -17,7 +17,7 @@
 
 ;; Building the index specifically requires Poppler's pdftotext, not
 ;; just any PDF to text converter. It has a critical feature over the
-;; others: conventional line feed characters (U+000C) are output
+;; others: conventional form feed characters (U+000C) are output
 ;; between pages, allowing precise tracking of page numbers. These are
 ;; the markers Emacs uses for `forward-page' and `backward-page'.
 


### PR DESCRIPTION
Small nit I picked up whilst reading the package description [on MELPA](https://melpa.org/#/x86-lookup):

> conventional _**line feed**_ characters (U+000C) are output between pages

Obviously, this should say **form feed**, as indicated by the code point. I assume this was a simple typo.