### PR TITLE
Fix non-interactive population of `x86-lookup-index`

### DIFF
--- a/x86-lookup.el
+++ b/x86-lookup.el
@@ -233,6 +233,8 @@ Defaults to the mnemonic under point."
                       "Mnemonic: ")))
        (list
         (completing-read prompt mnemonics nil t nil nil mnemonic)))))
+  (unless (called-interactively-p 'any)
+    (x86-lookup-ensure-index))
   (let ((page (cdr (assoc mnemonic x86-lookup-index))))
     (x86-lookup-browse-pdf (file-truename x86-lookup-pdf) page)))
 


### PR DESCRIPTION
Calling `x86-lookup` non-interactively (such as from a custom `x86-lookup-browse-pdf-function` handler) fails to populate `x86-lookup-cache` before the browser process is launched. Consequently, a `nil` page parameter is passed to the browse-pdf handler. This commit fixes that.

Observed using Alhadis/.emacs.d@dcf7abc.