### PR TITLE
Use `goto-char` instead of deprecated `point`

### DIFF
--- a/x86-lookup.el
+++ b/x86-lookup.el
@@ -150,7 +150,7 @@ This function requires the pdftotext command line program."
     (with-temp-buffer
       (call-process x86-lookup-pdftotext-program nil t nil
                     (file-truename pdf) "-")
-      (setf (point) (point-min))
+      (goto-char (point-min))
       (cl-loop for page upfrom 1
                while (< (point) (point-max))
                when (looking-at mnemonic)
@@ -180,7 +180,7 @@ This function requires the pdftotext command line program."
     (when (file-exists-p cache-path)
       (with-temp-buffer
         (insert-file-contents cache-path)
-        (setf (point) (point-min))
+        (goto-char (point-min))
         (ignore-errors (read (current-buffer)))))))
 
 (defun x86-lookup-ensure-index ()


### PR DESCRIPTION
Setting `(point)` is deprecated. Instead, it moves the point with `goto-char`. Fixes a warning.

Same issue as skeeto/nasm-mode#16